### PR TITLE
Fix entity configuration in DataContext

### DIFF
--- a/src/StromPriserWidgetAPI.Data/DataContext.cs
+++ b/src/StromPriserWidgetAPI.Data/DataContext.cs
@@ -6,9 +6,9 @@ namespace StromPriserWidgetAPI.Data
 
   public class DataContext : DbContext
   {
-    public DbSet<string> Zones { get; set; }
+    public DbSet<Zone> Zones { get; set; } = null!;
 
-    public DbSet<string> Prices { get; set; }
+    public DbSet<ZonePrice> Prices { get; set; } = null!;
 
     public DataContext(DbContextOptions options)
       : base(options)
@@ -21,6 +21,7 @@ namespace StromPriserWidgetAPI.Data
       base.OnModelCreating(builder);
 
       Zone.OnModelCreating(builder);
-      ImportTaskEntry.OnModelCreating(builder);
+      ZonePrice.OnModelCreating(builder);
     }
+  }
 }

--- a/src/StromPriserWidgetAPI.Data/Entities/Zone.cs
+++ b/src/StromPriserWidgetAPI.Data/Entities/Zone.cs
@@ -1,5 +1,17 @@
 namespace StromPriserWidgetAPI.Data.Entities;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
 public class Zone : StromPriserEntity<long, Zone>
 {
   public string Name { get; set; } = string.Empty;
+
+  internal static void OnModelCreating(ModelBuilder builder)
+  {
+    EntityTypeBuilder<Zone> e = builder.Entity<Zone>();
+    StromPriserEntity<long, Zone>.OnModelCreating(e);
+
+    e.Property(z => z.Name).IsRequired();
+  }
 }

--- a/src/StromPriserWidgetAPI.Data/Entities/ZonePrice.cs
+++ b/src/StromPriserWidgetAPI.Data/Entities/ZonePrice.cs
@@ -1,4 +1,8 @@
 namespace StromPriserWidgetAPI.Data.Entities;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
 public class ZonePrice : StromPriserEntity<long, ZonePrice>
 {
   public Zone Zone { get; set; } = new Zone();
@@ -6,4 +10,12 @@ public class ZonePrice : StromPriserEntity<long, ZonePrice>
   // NOK/kW
   public float Price { get; set; }
   public DateTime Date { get; set; }
+
+  internal static void OnModelCreating(ModelBuilder builder)
+  {
+    EntityTypeBuilder<ZonePrice> e = builder.Entity<ZonePrice>();
+    StromPriserEntity<long, ZonePrice>.OnModelCreating(e);
+
+    e.HasOne(zp => zp.Zone);
+  }
 }


### PR DESCRIPTION
## Summary
- configure `DataContext` with proper entity types
- add EF Core model configuration methods to `Zone` and `ZonePrice`

## Testing
- `dotnet build StromPriserWidgetAPI.sln --nologo` *(fails: dotnet not installed)*

------